### PR TITLE
Avoid adding redundant firstnames to user.bin

### DIFF
--- a/exec.post
+++ b/exec.post
@@ -34,13 +34,13 @@ cd ~/md380tools-vm
 ./addstatic
 
 
-if [ ! -f ~/fill.nickname.disable ]; then
-  echo -e "${YELLOW}Touching up ${ZCOM44}"
-  awk -F, '!length($6) {print $1","$2","$3","$4","$5","substr($3,1,index($3," ")-1)","$7;next} {print}' $userfile >$usertmp
-  cat $usertmp >$userfile
-  rm $usertmp
-  touch ~/filter.sys.enable
-fi
+#if [ ! -f ~/fill.nickname.disable ]; then
+#  echo -e "${YELLOW}Touching up ${ZCOM44}"
+#  awk -F, '!length($6) {print $1","$2","$3","$4","$5","substr($3,1,index($3," ")-1)","$7;next} {print}' $userfile >$usertmp
+#  cat $usertmp >$userfile
+#  rm $usertmp
+#  touch ~/filter.sys.enable
+#fi
 
 if [ -f filter.sys ] && [ ! -f ~/filter.sys.disable ]; then  
   ./filter.sys $userfile

--- a/root/display.c
+++ b/root/display.c
@@ -186,6 +186,22 @@ void draw_micbargraph()
     }
 }
 
+char *get_firstname(user_t *up, char *buf, int buflen) {
+    if (*up->firstname != 0)
+	return up->firstname;
+
+    char *p = buf;
+    char *q = up->name;
+    for (int i = 0; i < buflen-1 && *q != ' ' && *q != 0; i++)
+	*p++ = *q++;
+
+    *p = 0;
+
+    return buf;
+}
+
+#define FIRSTNAME_BUFSIZE 30
+
 #define RX_POPUP_Y_START 22 // 24
 #define RX_POPUP_X_START 4  // 10
 
@@ -213,6 +229,7 @@ void draw_rx_screen(unsigned int bg_color)
     gfx_select_font(gfx_font_small);
 
     user_t usr ;
+    char firstname_buf[FIRSTNAME_BUFSIZE];
 
     if( usr_find_by_dmrid(&usr,src) == 0 ) {
 		if( src==4000 ) {
@@ -253,7 +270,8 @@ void draw_rx_screen(unsigned int bg_color)
     y_index += GFX_FONT_SMALL_HEIGHT ;
 
     gfx_select_font(gfx_font_norm); // switch to large font
-    gfx_printf_pos2(RX_POPUP_X_START, y_index, 10, "%s %s", usr.callsign, usr.firstname );
+    char *firstname = get_firstname(&usr, firstname_buf, FIRSTNAME_BUFSIZE);
+    gfx_printf_pos2(RX_POPUP_X_START, y_index, 10, "%s %s", usr.callsign, firstname );
     y_index += GFX_FONT_NORML_HEIGHT; 
 
     if ( global_addl_config.userscsv > 1 && talkerAlias.length > 0 ) {		// 2017-02-19 show Talker Alias depending on setup 0=CPS 1=DB 2=TA 3=TA & DB
@@ -370,6 +388,7 @@ void draw_ta_screen(unsigned int bg_color)
     gfx_select_font(gfx_font_small);
 
     user_t usr ;
+    char firstname_buf[FIRSTNAME_BUFSIZE];
     
     int y_index = RX_POPUP_Y_START;
     
@@ -395,7 +414,8 @@ void draw_ta_screen(unsigned int bg_color)
     {
 	gfx_puts_pos(RX_POPUP_X_START, y_index, "No userdb info");
     } else {
-        gfx_printf_pos(RX_POPUP_X_START, y_index, "%s %s", usr.callsign, usr.firstname );
+	char *firstname = get_firstname(&usr, firstname_buf, FIRSTNAME_BUFSIZE);
+        gfx_printf_pos(RX_POPUP_X_START, y_index, "%s %s", usr.callsign, firstname );
     }
     y_index += GFX_FONT_SMALL_HEIGHT ; // previous line was in small font
 


### PR DESCRIPTION
Most of the entries in user.bin have a firstname field that matches
the first whitespace-separated part of the name field. Here, we
avoid the need for that by displaying the first part of the name
field if the firstname field is empty.

This reduces the size of user.bin without losing any functionality.