### PR TITLE
Fix kd4z.applet.patch to match md380tools changes

### DIFF
--- a/root/kd4z.applet.patch
+++ b/root/kd4z.applet.patch
@@ -136,121 +136,21 @@ Only in /home/tyt/md380tools/applet/src/: narrator.c
 Only in /home/tyt/md380tools/applet/src/: narrator.h
 Only in /home/tyt/md380tools/applet/src/: netmon.c
 diff -rBu4 /home/tyt/md380tools/applet/src/netmon.h /home/tyt/src/md380tools/applet/src/netmon.h
---- /home/tyt/md380tools/applet/src/netmon.h	2018-02-14 13:52:29.127758570 -0600
-+++ /home/tyt/src/md380tools/applet/src/netmon.h	2018-02-14 07:11:18.000000000 -0600
-@@ -1,56 +1,56 @@
--/*
-- *  netmon.h
-- * 
-- */
--
--#ifndef NETMON_H
--#define NETMON_H
--
--#include <stdint.h>
--
--#include "console.h"
--#include "addl_config.h"
--
--#ifdef __cplusplus
--extern "C" {
--#endif
--
--void netmon_update();
--
--extern uint8_t last_radio_event ;
--extern uint8_t last_event2 ;
--extern uint8_t last_event3 ;
--extern uint8_t last_event4 ;
--extern uint8_t last_event5 ;
--
--extern uint8_t nm_screen ;
--extern uint8_t nm_started ;
--extern uint8_t nm_started5 ;
--extern uint8_t nm_started6 ;
--extern uint8_t rx_voice ;
--
--inline int is_netmon_enabled()
--{
--    return global_addl_config.netmon != 0 ;
--}
--
--inline int is_netmon_visible()
--{
+--- /home/tyt/md380tools/applet/src/netmon.h	2018-06-15 12:13:03.263738420 -0700
++++ /home/tyt/src/md380tools/applet/src/netmon.h	2018-07-17 08:34:43.765907270 -0700
+@@ -40,9 +40,9 @@
+ 
+ inline int is_netmon_visible()
+ {
 -    if( !is_netmon_enabled() ) {
 -        return 0 ;
 -    }
--    return nm_screen != 0 ;
--    //return !is_menu_visible();
--}
--
--inline int is_statusline_visible()
--{    
--    return global_addl_config.datef == 5 ;
--}
--
--#ifdef __cplusplus
--}
--#endif
--
--#endif /* NETMON_H */
--
-+/*
-+ *  netmon.h
-+ * 
-+ */
-+
-+#ifndef NETMON_H
-+#define NETMON_H
-+
-+#include <stdint.h>
-+
-+#include "console.h"
-+#include "addl_config.h"
-+
-+#ifdef __cplusplus
-+extern "C" {
-+#endif
-+
-+void netmon_update();
-+
-+extern uint8_t last_radio_event ;
-+extern uint8_t last_event2 ;
-+extern uint8_t last_event3 ;
-+extern uint8_t last_event4 ;
-+extern uint8_t last_event5 ;
-+
-+extern uint8_t nm_screen ;
-+extern uint8_t nm_started ;
-+extern uint8_t nm_started5 ;
-+extern uint8_t nm_started6 ;
-+extern uint8_t rx_voice ;
-+
-+inline int is_netmon_enabled()
-+{
-+    return global_addl_config.netmon != 0 ;
-+}
-+
-+inline int is_netmon_visible()
-+{
 +    //if( !is_netmon_enabled() ) {
 +    //    return 0 ;
 +   // }
-+    return nm_screen != 0 ;
-+    //return !is_menu_visible();
-+}
-+
-+inline int is_statusline_visible()
-+{    
-+    return global_addl_config.datef == 5 ;
-+}
-+
-+#ifdef __cplusplus
-+}
-+#endif
-+
-+#endif /* NETMON_H */
-+
+     return nm_screen != 0 ;
+     //return !is_menu_visible();
+ }
 Only in /home/tyt/md380tools/applet/src/: os.c
 Only in /home/tyt/md380tools/applet/src/: os.h
 Only in /home/tyt/md380tools/applet/src/: printf.c


### PR DESCRIPTION
Applying root/kd4z.applet.patch failed when attempting to patch
~/md380tools/applet/src/netmon.h.  This is because of changes
in this md380tools commit:
	commit 716da33550ecbf08c63d5ecfacc695c8a5f60b3d
	Author: DL2MF <meinhard.guenther@gmail.com>
	Date:   Sat Jan 6 20:44:01 2018 +0100

	    adding TS to RX display and lastheard

I noticed that the patch contained the entirety of netmon.h, rather
than just the 3 changed lines.  I updated the patch so it contains
the minimal changes to avoid conflicts like this in the future.