### PR TITLE
Fix compile time error when nosleep hack enabled

### DIFF
--- a/root/kd4z.nosleep.patch
+++ b/root/kd4z.nosleep.patch
@@ -49,10 +49,12 @@ diff -rBu4 /home/tyt/md380tools/applet/src/irq_handlers.c /home/tyt/src/md380too
  #endif
 -
 +// kd4z nosleep hack for version 5 hardware until unsleep can be hooked
++#ifdef MD380_ADDR_DMR_POWER_SAVE_COUNTDOWN
 +if ( *((uint16_t*)MD380_ADDR_DMR_POWER_SAVE_COUNTDOWN) < 20 )
 +{
 +  *((uint16_t*)MD380_ADDR_DMR_POWER_SAVE_COUNTDOWN) |= 0x80 + 0x40;
 +}
++#endif
    if( boot_flags & BOOT_FLAG_OPEN_FOR_BUSINESS )
     { // 2017-05-14 : Removed the brightness 'ramp-up' test. 
       //   The 9 intensity levels can now be tested in app_menu.c in inc/dec edit mode.


### PR DESCRIPTION
With the no-sleep patch enabled, a compile-time error happens due to MD380_ADDR_DMR_POWER_SAVE_COUNTDOWN being undefined in some cases. Everywhere else in irq_handlers.c, access to this register is guarded by #ifdefs around the code checking for this symbol's existence before using it. This commit adds the same #ifdef check to the KD4Z hack to allow 'make dist' to finish successfully.