### PR TITLE
Fix spelling error "Colorada" -> "Colorado"

### DIFF
--- a/root/displayEnhanced.c
+++ b/root/displayEnhanced.c
@@ -186,7 +186,7 @@ static const char *const states[] = {
 	"CA,California",
      "CAL,Calabria",
      "CAM,Campania",
-	"CO,Colorada",
+	"CO,Colorado",
 	"CT,Connecticut",
 	"DC,District of Columbia",
 	"DE,Delaware",


### PR DESCRIPTION
Reported by: Don Frank <dhf35@comcast.net>

Signed-off-by: Dale Farnsworth <dale@farnsworth.org>